### PR TITLE
fix client http errors code handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,8 @@ env:
 cache:
   directories:
     - eggs
-before_install:
-  - pip install setuptools==7.0
-  - python2 bootstrap.py
 install:
-  - bin/buildout -N
+  - sh bootstrap.sh
 script:
   - bin/nosetests
 after_success:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+virtualenv .
+./bin/pip install setuptools==33.1.1
+./bin/pip install zc.buildout
+./bin/buildout -N
+

--- a/openprocurement/bridge/competitivedialogue/databridge.py
+++ b/openprocurement/bridge/competitivedialogue/databridge.py
@@ -112,7 +112,7 @@ def check_status_response(func):
                 obj.headers['Cookie'] = re.response.headers['Set-Cookie']
                 response = func(obj, *args, **kwargs)
             else:
-                raise ResourceError(re)
+                raise
         return response
     return func_wrapper
 

--- a/openprocurement/bridge/competitivedialogue/tests/main.py
+++ b/openprocurement/bridge/competitivedialogue/tests/main.py
@@ -1,11 +1,27 @@
 # -*- coding: utf-8 -*-
-
+from mock import MagicMock, patch, Mock
+from openprocurement.bridge.competitivedialogue.databridge import TendersClientSync
+from restkit.errors import ResourceError
 import unittest
+
+
+class TenderClientTestCase(unittest.TestCase):
+
+    def test_exception_access_http_code(self):
+        with patch("openprocurement_client.client.TendersClientSync.create_tender") as create_tender:
+            create_tender.side_effect = ResourceError(msg="Hi", http_code=422)
+
+            client = TendersClientSync("", host_url="https://lb-api-sandbox.prozorro.gov.ua", api_version="2.4")
+
+            with self.assertRaises(ResourceError) as exc:
+                client.create_tender({})
+
+            self.assertEqual(exc.exception.status_int, 422)
 
 
 def suite():
     suite = unittest.TestSuite()
-    # TODO -add tests
+    suite.addTest(unittest.makeSuite(TenderClientTestCase))
     return suite
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,13 @@ requires = [
     'PyYAML',
     'gevent',
     'restkit',
-    'openprocurement_client>=1.0b2',
+    'openprocurement_client==1.0b2',
 ]
 
 test_requires = requires + [
     'webtest',
     'python-coveralls',
+    'mock',
 ]
 
 docs_requires = requires + [


### PR DESCRIPTION
https://jira.prozorro.org/browse/CS-3559#

1) Поправил декоратор check_status_response . Он отлавливает 412 - все остальные ошибки ререйзит, но неверно. По итогу у ошибок нет http кода, а он нужен. 

2) Зафиксировал версию клиент либы, тк у более поздних версий меняется структура (не работают импорты) и кто знает что еще. На песочнице сейчас эта версия, пусть она и будет.

3) bootstrap.sh -  Версия setuptools как раз такая, что и старые либы устанавливаются (типо клиент либы) и новые типо mock 2.0.0. 